### PR TITLE
PETALSSECAMEL-42 trim java-routes

### DIFF
--- a/petals-se-camel/src/main/java/org/ow2/petals/se/camel/utils/CamelRoutesHelper.java
+++ b/petals-se-camel/src/main/java/org/ow2/petals/se/camel/utils/CamelRoutesHelper.java
@@ -36,8 +36,11 @@ public class CamelRoutesHelper {
 
     public static RouteBuilder loadRoutesFromClass(final ClassLoader classLoader, final String className)
             throws InvalidJBIConfigurationException {
+        if (Strings.isNullOrEmpty(className)) {
+            throw new InvalidJBIConfigurationException("className must not be null or empty");
+        }
         try {
-            final Class<?> clazz = classLoader.loadClass(className);
+            final Class<?> clazz = classLoader.loadClass(className.trim());
             final Object o = clazz.newInstance();
             if (!(o instanceof RouteBuilder)) {
                 throw new InvalidJBIConfigurationException(className + " is not a subclass of Camel RouteBuilder");

--- a/petals-se-camel/src/test/java/org/ow2/petals/se/camel/utils/CamelRoutesHelperTest.java
+++ b/petals-se-camel/src/test/java/org/ow2/petals/se/camel/utils/CamelRoutesHelperTest.java
@@ -96,14 +96,14 @@ public class CamelRoutesHelperTest extends Assert {
     @Test
     public void testLoadRoutesClass_ko_empty_className() throws InvalidJBIConfigurationException {
         thrown.expect(InvalidJBIConfigurationException.class);
-        thrown.expectMessage("is not a subclass of Camel RouteBuilder");
+        thrown.expectMessage("className must not be null or empty");
         CamelRoutesHelper.loadRoutesFromClass(getClass().getClassLoader(), "");
     }
 
     @Test
     public void testLoadRoutesClass_ko_null_className() throws InvalidJBIConfigurationException {
         thrown.expect(InvalidJBIConfigurationException.class);
-        thrown.expectMessage("is not a subclass of Camel RouteBuilder");
+        thrown.expectMessage("className must not be null or empty");
         CamelRoutesHelper.loadRoutesFromClass(getClass().getClassLoader(), null);
     }
 }

--- a/petals-se-camel/src/test/java/org/ow2/petals/se/camel/utils/CamelRoutesHelperTest.java
+++ b/petals-se-camel/src/test/java/org/ow2/petals/se/camel/utils/CamelRoutesHelperTest.java
@@ -93,4 +93,17 @@ public class CamelRoutesHelperTest extends Assert {
                 Logger.getLogger("TEST"));
     }
 
+    @Test
+    public void testLoadRoutesClass_ko_empty_className() throws InvalidJBIConfigurationException {
+        thrown.expect(InvalidJBIConfigurationException.class);
+        thrown.expectMessage("is not a subclass of Camel RouteBuilder");
+        CamelRoutesHelper.loadRoutesFromClass(getClass().getClassLoader(), "");
+    }
+
+    @Test
+    public void testLoadRoutesClass_ko_null_className() throws InvalidJBIConfigurationException {
+        thrown.expect(InvalidJBIConfigurationException.class);
+        thrown.expectMessage("is not a subclass of Camel RouteBuilder");
+        CamelRoutesHelper.loadRoutesFromClass(getClass().getClassLoader(), null);
+    }
 }


### PR DESCRIPTION
Trim java-routes déclared in jbi.xml

throw InvalidJBIConfigurationException if className are null or empty (avoid NullPointerException if className are null)

https://jira.petalslink.com/browse/PETALSSECAMEL-42
